### PR TITLE
Use new Web Api standard features

### DIFF
--- a/packages/varlet-touch-emulator/iife.js
+++ b/packages/varlet-touch-emulator/iife.js
@@ -51,8 +51,8 @@
 
   function triggerTouch(touchType, mouseEvent) {
     const { altKey, ctrlKey, metaKey, shiftKey } = mouseEvent
-    const touchEvent = document.createEvent('Event')
-    touchEvent.initEvent(touchType, true, true)
+    const touchEvent = new Event(touchType, {bubbles:true, cancelable:true})
+
 
     touchEvent.altKey = altKey
     touchEvent.ctrlKey = ctrlKey

--- a/packages/varlet-touch-emulator/index.js
+++ b/packages/varlet-touch-emulator/index.js
@@ -50,8 +50,8 @@ function getActiveTouches(mouseEvent) {
 
 function triggerTouch(touchType, mouseEvent) {
   const { altKey, ctrlKey, metaKey, shiftKey } = mouseEvent
-  const touchEvent = document.createEvent('Event')
-  touchEvent.initEvent(touchType, true, true)
+  const touchEvent = new Event(touchType, {bubbles:true, cancelable:true})
+
 
   touchEvent.altKey = altKey
   touchEvent.ctrlKey = ctrlKey


### PR DESCRIPTION
## Checklist

---

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

---

### Discovery **event Initevent ()** has been removed from the web standard. Although some browsers still support it, the official statement may **stop supporting** it at some time in the future, so a specific **event constructor** function is adopted