### PR TITLE
fix: fix the `docs` logo position style

### DIFF
--- a/packages/varlet-cli/site/pc/components/LogoAnimation.vue
+++ b/packages/varlet-cli/site/pc/components/LogoAnimation.vue
@@ -74,7 +74,7 @@ export default defineComponent({
 }
 
 .logo-animation {
-  position: absolute;
+  position: fixed;
   z-index: 10;
   pointer-events: none;
 }

--- a/packages/varlet-cli/site/pc/pages/index.en-US.vue
+++ b/packages/varlet-cli/site/pc/pages/index.en-US.vue
@@ -100,7 +100,7 @@ watch(() => route.path, togglePageTitle, { immediate: true })
             src="https://madewithnetworkfra.fra1.digitaloceanspaces.com/spatie-space-production/28269/varlet-ui.jpg"
           />
         </div>
-        <div class="base-descrition introduce-descrition">
+        <div class="base-description introduce-description">
           Material style mobile terminal component library for vue3
         </div>
       </div>


### PR DESCRIPTION
## Checklist

---

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

---

close #535 