### PR TITLE
fix(ui/BottomNavigation): change repeat trigger

### DIFF
--- a/packages/varlet-ui/src/bottom-navigation/BottomNavigation.vue
+++ b/packages/varlet-ui/src/bottom-navigation/BottomNavigation.vue
@@ -85,6 +85,10 @@ export default defineComponent({
     }
 
     const onToggle = (changedValue: number | string) => {
+      if (active.value === changedValue) {
+        return
+      }
+
       props.onBeforeChange ? handleBeforeChange(changedValue) : handleChange(changedValue)
     }
 

--- a/packages/varlet-ui/src/bottom-navigation/__tests__/index.spec.js
+++ b/packages/varlet-ui/src/bottom-navigation/__tests__/index.spec.js
@@ -62,6 +62,10 @@ describe('test bottom-navigation events', () => {
     await trigger(wrapper.findAll('.var-bottom-navigation-item')[1], 'click')
     expect(handleChange).toHaveBeenCalledTimes(1)
     expect(dummy).toBe(1)
+
+    await trigger(wrapper.findAll('.var-bottom-navigation-item')[1], 'click')
+    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(dummy).toBe(1)
     wrapper.unmount()
   })
 
@@ -128,6 +132,12 @@ describe('test bottom-navigation events', () => {
     await trigger(wrapper.findAll('.var-bottom-navigation-item')[1], 'click')
     expect(handleBeforeChange).toHaveBeenCalledTimes(1)
     expect(wrapper.vm.active).toBe(0)
+    await delay(200)
+    expect(wrapper.vm.active).toBe(1)
+
+    await trigger(wrapper.findAll('.var-bottom-navigation-item')[1], 'click')
+    expect(handleBeforeChange).toHaveBeenCalledTimes(1)
+    expect(wrapper.vm.active).toBe(1)
     await delay(200)
     expect(wrapper.vm.active).toBe(1)
 


### PR DESCRIPTION
## Checklist


- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information
`change` event repeat trigger, see [there](https://varlet.gitee.io/varlet-ui-playground/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmltcG9ydCB7IFNuYWNrYmFyIH0gZnJvbSAnQHZhcmxldC91aSdcblxuY29uc3QgYWN0aXZlID0gcmVmKDApXG5jb25zdCBoYW5kbGVDaGFuZ2UgPSAoYWN0aXZlKSA9PiB7XG4gIGNvbnNvbGUubG9nKCd0aWdnZXInKVxuICBTbmFja2Jhci5pbmZvKGBjaGFuZ2VkIHRvICR7YWN0aXZlfWApXG59XG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8dmFyLWJvdHRvbS1uYXZpZ2F0aW9uIHYtbW9kZWw6YWN0aXZlPVwiYWN0aXZlXCIgQGNoYW5nZT1cImhhbmRsZUNoYW5nZVwiPlxuICAgIDx2YXItYm90dG9tLW5hdmlnYXRpb24taXRlbSBsYWJlbD1cIuagh+etvlwiIGljb249XCJob21lXCIgLz5cbiAgICA8dmFyLWJvdHRvbS1uYXZpZ2F0aW9uLWl0ZW0gbGFiZWw9XCLmoIfnrb5cIiBpY29uPVwibWFnbmlmeVwiIC8+XG4gICAgPHZhci1ib3R0b20tbmF2aWdhdGlvbi1pdGVtIGxhYmVsPVwi5qCH562+XCIgaWNvbj1cImhlYXJ0XCIgLz5cbiAgICA8dmFyLWJvdHRvbS1uYXZpZ2F0aW9uLWl0ZW0gbGFiZWw9XCLmoIfnrb5cIiBpY29uPVwiYWNjb3VudC1jaXJjbGVcIiAvPlxuICA8L3Zhci1ib3R0b20tbmF2aWdhdGlvbj5cbjwvdGVtcGxhdGU+IiwiUGxheWdyb3VuZC52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBpbnN0YWxsVmFybGV0VUkgfSBmcm9tICcuL3ZhcmxldC1yZXBsLXBsdWdpbi5qcydcblxuaW5zdGFsbFZhcmxldFVJKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVlL3J1bnRpbWUtZG9tQDMuMi4yOS9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdmFybGV0L3VpXCI6IFwiLi92YXJsZXQuZXNtLmpzXCIsXG4gICAgXCJAdmFybGV0L3RvdWNoLWVtdWxhdG9yXCI6IFwiLi92YXJsZXQtdG91Y2gtZW11bGF0b3IuanNcIixcbiAgICBcIkB2YXJsZXQvdWkvanNvbi9hcmVhLmpzb25cIjogXCIuL3ZhcmxldC1hcmVhLmpzXCJcbiAgfVxufSIsInZhcmxldC1yZXBsLXBsdWdpbi5qcyI6ImltcG9ydCBWYXJsZXRVSSwgeyBDb250ZXh0IH0gZnJvbSAnQHZhcmxldC91aSdcbmltcG9ydCAnQHZhcmxldC90b3VjaC1lbXVsYXRvcidcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxuQ29udGV4dC50b3VjaG1vdmVGb3JiaWQgPSBmYWxzZVxuXG5hd2FpdCBhcHBlbmRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBpbnN0YWxsVmFybGV0VUkoKSB7XG4gIGNvbnN0IHsgcGFyZW50IH0gPSB3aW5kb3dcblxuICBjb25zdCBzdHlsZSA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ3N0eWxlJylcbiAgc3R5bGUuaW5uZXJIVE1MID0gYFxuICAgIGJvZHkge1xuICAgICAgbWluLWhlaWdodDogMTAwdmg7XG4gICAgICBwYWRkaW5nOiAxNnB4O1xuICAgICAgbWFyZ2luOiAwO1xuICAgICAgY29sb3I6IHZhcigtLWNvbG9yLXRleHQpO1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tY29sb3ItYm9keSk7XG4gICAgfVxuXG4gICAgKjo6LXdlYmtpdC1zY3JvbGxiYXIge1xuICAgICAgZGlzcGxheTogbm9uZTtcbiAgICB9XG4gIGBcbiAgZG9jdW1lbnQuaGVhZC5hcHBlbmRDaGlsZChzdHlsZSlcblxuICBpZiAocGFyZW50LmRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5jbGFzc0xpc3QuY29udGFpbnMoJ2RhcmsnKSkge1xuICAgIFZhcmxldFVJLlN0eWxlUHJvdmlkZXIoVmFybGV0VUkuVGhlbWVzLmRhcmspXG4gIH1cblxuICB3aW5kb3cuYWRkRXZlbnRMaXN0ZW5lcignbWVzc2FnZScsICh7IGRhdGEgfSkgPT4ge1xuICAgIGlmIChkYXRhLmFjdGlvbiA9PT0gJ3RoZW1lLWNoYW5nZScpIHtcbiAgICAgIFZhcmxldFVJLlN0eWxlUHJvdmlkZXIoZGF0YS52YWx1ZSA9PT0gJ2RhcmsnID8gVmFybGV0VUkuVGhlbWVzLmRhcmsgOiBudWxsKVxuICAgIH1cbiAgfSlcblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShWYXJsZXRVSSlcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGFwcGVuZFN0eWxlKCkge1xuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgIGxpbmsuaHJlZiA9ICcuL3ZhcmxldC5jc3MnXG4gICAgbGluay5vbmxvYWQgPSByZXNvbHZlXG4gICAgbGluay5vbmVycm9yID0gcmVqZWN0XG4gICAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChsaW5rKVxuICB9KVxufVxuIn0=)

`handleChange` keeps triggering when the `item` is clicked repeatedly. I think the `change` event should only fire when the active is different.
