### PR TITLE
fix(ui/collapse): fix shadow invisibility of collapse

### DIFF
--- a/packages/varlet-ui/src/collapse/Collapse.vue
+++ b/packages/varlet-ui/src/collapse/Collapse.vue
@@ -137,5 +137,6 @@ export default defineComponent({
 .var-collapse {
   position: relative;
   width: 100%;
+  z-index: 0;
 }
 </style>


### PR DESCRIPTION
## Checklist
- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information
由于`.var-collapse-item:before`中使用`z-index: -1`，当存在其他元素设置背景后，由于根层叠上下文原因会显示在背景之后，导致阴影显示出现问题。
![image](https://user-images.githubusercontent.com/39904328/197392860-103b9738-b273-4dc6-9712-3568cd547b56.png)
- Varlet UI Playground中的样例请看[这里](https://varlet.gitee.io/varlet-ui-playground/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPSd0cyc+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5jb25zdCB2YWx1ZSA9IHJlZihbJzEnXSlcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxkaXYgc3R5bGU9XCJiYWNrZ3JvdW5kOndoaXRlXCI+XG4gICAgPHZhci1jb2xsYXBzZSB2LW1vZGVsPVwidmFsdWVcIj5cbiAgICA8dmFyLWNvbGxhcHNlLWl0ZW0gdGl0bGU9XCLmoIfpophcIiBuYW1lPVwiMVwiPuaWh+acrDwvdmFyLWNvbGxhcHNlLWl0ZW0+XG4gICAgPHZhci1jb2xsYXBzZS1pdGVtIHRpdGxlPVwi5qCH6aKYXCIgbmFtZT1cIjJcIj7mlofmnKw8L3Zhci1jb2xsYXBzZS1pdGVtPlxuICA8L3Zhci1jb2xsYXBzZT5cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuPHN0eWxlPlxuPC9zdHlsZT5cbiIsIlBsYXlncm91bmQudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgaW5zdGFsbFZhcmxldFVJIH0gZnJvbSAnLi92YXJsZXQtcmVwbC1wbHVnaW4uanMnXG5cbmluc3RhbGxWYXJsZXRVSSgpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vQHZ1ZS9ydW50aW1lLWRvbUAzLjIuMjkvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZhcmxldC91aVwiOiBcIi4vdmFybGV0LmVzbS5qc1wiLFxuICAgIFwiQHZhcmxldC90b3VjaC1lbXVsYXRvclwiOiBcIi4vdmFybGV0LXRvdWNoLWVtdWxhdG9yLmpzXCIsXG4gICAgXCJAdmFybGV0L3VpL2pzb24vYXJlYS5qc29uXCI6IFwiLi92YXJsZXQtYXJlYS5qc1wiXG4gIH1cbn0iLCJ2YXJsZXQtcmVwbC1wbHVnaW4uanMiOiJpbXBvcnQgVmFybGV0VUksIHsgQ29udGV4dCB9IGZyb20gJ0B2YXJsZXQvdWknXG5pbXBvcnQgJ0B2YXJsZXQvdG91Y2gtZW11bGF0b3InXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbkNvbnRleHQudG91Y2htb3ZlRm9yYmlkID0gZmFsc2VcblxuYXdhaXQgYXBwZW5kU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gaW5zdGFsbFZhcmxldFVJKCkge1xuICBjb25zdCB7IHBhcmVudCB9ID0gd2luZG93XG5cbiAgY29uc3Qgc3R5bGUgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdzdHlsZScpXG4gIHN0eWxlLmlubmVySFRNTCA9IGBcbiAgICBib2R5IHtcbiAgICAgIG1pbi1oZWlnaHQ6IDEwMHZoO1xuICAgICAgcGFkZGluZzogMTZweDtcbiAgICAgIG1hcmdpbjogMDtcbiAgICAgIGNvbG9yOiB2YXIoLS1jb2xvci10ZXh0KTtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWNvbG9yLWJvZHkpO1xuICAgIH1cblxuICAgICo6Oi13ZWJraXQtc2Nyb2xsYmFyIHtcbiAgICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgfVxuICBgXG4gIGRvY3VtZW50LmhlYWQuYXBwZW5kQ2hpbGQoc3R5bGUpXG5cbiAgaWYgKHBhcmVudC5kb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuY2xhc3NMaXN0LmNvbnRhaW5zKCdkYXJrJykpIHtcbiAgICBWYXJsZXRVSS5TdHlsZVByb3ZpZGVyKFZhcmxldFVJLlRoZW1lcy5kYXJrKVxuICB9XG5cbiAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ21lc3NhZ2UnLCAoeyBkYXRhIH0pID0+IHtcbiAgICBpZiAoZGF0YS5hY3Rpb24gPT09ICd0aGVtZS1jaGFuZ2UnKSB7XG4gICAgICBWYXJsZXRVSS5TdHlsZVByb3ZpZGVyKGRhdGEudmFsdWUgPT09ICdkYXJrJyA/IFZhcmxldFVJLlRoZW1lcy5kYXJrIDogbnVsbClcbiAgICB9XG4gIH0pXG5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoVmFybGV0VUkpXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBhcHBlbmRTdHlsZSgpIHtcbiAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICBsaW5rLmhyZWYgPSAnLi92YXJsZXQuY3NzJ1xuICAgIGxpbmsub25sb2FkID0gcmVzb2x2ZVxuICAgIGxpbmsub25lcnJvciA9IHJlamVjdFxuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kQ2hpbGQobGluaylcbiAgfSlcbn1cbiJ9)
> 在`Varlet UI Playground`中的受影响情况稍有区别，但仍然存在问题
## fix
在`.var-collapse`中创建新的层叠上下文。
```
.var-collapse {
  ...
  z-index: 0;
}
```
![image](https://user-images.githubusercontent.com/39904328/197393471-23f4e506-0de8-41f2-874e-d8e32261cc22.png)
