### PR TITLE
fix: error suffix when create tsx component

### DIFF
--- a/packages/varlet-cli/template/create/index.ts.ejs
+++ b/packages/varlet-cli/template/create/index.ts.ejs
@@ -1,5 +1,5 @@
 // Component entry, the folder where the file exists will be exposed to the user
-import <%- bigCamelizeName %> from './<%- bigCamelizeName %>.vue'
+import <%- bigCamelizeName %> from './<%- bigCamelizeName %><%- style === 'vue' ? '.vue' : '' %>'
 import type { App } from 'vue'
 
 <%- bigCamelizeName %>.install = function(app: App) {


### PR DESCRIPTION
## Checklist

---

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information
修改当用tsx新建组件时，组件index.ts文件中引用组件文件后缀错误的问题
---
