### PR TITLE
fix(ui/image-preview): click can't trigger a close event sometimes

### DIFF
--- a/packages/varlet-ui/src/image-preview/ImagePreview.vue
+++ b/packages/varlet-ui/src/image-preview/ImagePreview.vue
@@ -171,8 +171,9 @@ export default defineComponent({
     }
 
     const handleTouchend = (event: Event) => {
+      const isTapEvent = isTapTouch(event.target as HTMLElement)
       checker = window.setTimeout(() => {
-        isTapTouch(event.target as HTMLElement) && close()
+        isTapEvent && close()
         startTouch = null
       }, EVENT_DELAY)
     }


### PR DESCRIPTION
## Checklist

---

- [ ] fix bug about clicking can't trigger a close event sometimes

## Change information

---

- [ ] modified some content related to the close event of the image preview component

##  Notes

I replicated this bug using varlet playground,  you can try it out. 

https://github.com/varletjs/varlet/assets/70570907/61abdd5e-5d52-42b1-86d3-2c19b04d96f7

https://varlet.gitee.io/varlet-ui-playground/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPSd0cyc+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IHNob3dJbWFnZSA9IHJlZihmYWxzZSlcbmNvbnN0IGltYWdlTGlzdCA9IHJlZihbJ2h0dHBzOi8vdmFybGV0LmdpdGVlLmlvL3ZhcmxldC11aS9jYXQuanBnJ10pXG5cbmNvbnN0IHRvZ2dsZSA9ICgpID0+IHtcbiAgc2hvd0ltYWdlLnZhbHVlID0gIXNob3dJbWFnZS52YWx1ZVxufVxuXG5jb25zdCBoYW5kbGVDbGljayA9ICgpID0+IHtcbiAgY29uc29sZS5sb2coJ3lvdSBjbGlja2VkISEhJylcbn1cbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxkaXYgQGNsaWNrPVwiaGFuZGxlQ2xpY2tcIj5cbiAgICA8dmFyLWJ1dHRvbiB0eXBlPVwicHJpbWFyeVwiIEBjbGljaz1cInRvZ2dsZVwiPnRvZ2dsZTwvdmFyLWJ1dHRvbj5cbiA8dmFyLWltYWdlLXByZXZpZXdcbiAgICA6aW1hZ2VzPVwiaW1hZ2VMaXN0XCJcbiAgICB2LW1vZGVsOnNob3c9XCJzaG93SW1hZ2VcIlxuICAvPlxuICA8L2Rpdj5cbiAgXG48L3RlbXBsYXRlPlxuIiwiUGxheWdyb3VuZC52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBpbnN0YWxsVmFybGV0VUkgfSBmcm9tICcuL3ZhcmxldC1yZXBsLXBsdWdpbi5qcydcblxuaW5zdGFsbFZhcmxldFVJKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVlL3J1bnRpbWUtZG9tQDMuMy4yL2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2YXJsZXQvdWlcIjogXCIuL3ZhcmxldC5lc20uanNcIixcbiAgICBcIkB2YXJsZXQvdG91Y2gtZW11bGF0b3JcIjogXCIuL3ZhcmxldC10b3VjaC1lbXVsYXRvci5qc1wiLFxuICAgIFwiQHZhcmxldC91aS9qc29uL2FyZWEuanNvblwiOiBcIi4vdmFybGV0LWFyZWEuanNcIlxuICB9XG59IiwidmFybGV0LXJlcGwtcGx1Z2luLmpzIjoiaW1wb3J0IFZhcmxldFVJLCB7IENvbnRleHQgfSBmcm9tICdAdmFybGV0L3VpJ1xuaW1wb3J0ICdAdmFybGV0L3RvdWNoLWVtdWxhdG9yJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5hd2FpdCBhcHBlbmRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBpbnN0YWxsVmFybGV0VUkoKSB7XG4gIGNvbnN0IHsgcGFyZW50IH0gPSB3aW5kb3dcblxuICBjb25zdCBzdHlsZSA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ3N0eWxlJylcbiAgc3R5bGUuaW5uZXJIVE1MID0gYFxuICAgIGJvZHkge1xuICAgICAgbWluLWhlaWdodDogMTAwdmg7XG4gICAgICBwYWRkaW5nOiAxNnB4O1xuICAgICAgbWFyZ2luOiAwO1xuICAgICAgY29sb3I6IHZhcigtLWNvbG9yLXRleHQpO1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tY29sb3ItYm9keSk7XG4gICAgfVxuXG4gICAgKjo6LXdlYmtpdC1zY3JvbGxiYXIge1xuICAgICAgZGlzcGxheTogbm9uZTtcbiAgICB9XG4gIGBcbiAgZG9jdW1lbnQuaGVhZC5hcHBlbmRDaGlsZChzdHlsZSlcblxuICBpZiAocGFyZW50LmRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5jbGFzc0xpc3QuY29udGFpbnMoJ2RhcmsnKSkge1xuICAgIFZhcmxldFVJLlN0eWxlUHJvdmlkZXIoVmFybGV0VUkuVGhlbWVzLmRhcmspXG4gIH1cblxuICB3aW5kb3cuYWRkRXZlbnRMaXN0ZW5lcignbWVzc2FnZScsICh7IGRhdGEgfSkgPT4ge1xuICAgIGlmIChkYXRhLmFjdGlvbiA9PT0gJ3RoZW1lLWNoYW5nZScpIHtcbiAgICAgIFZhcmxldFVJLlN0eWxlUHJvdmlkZXIoZGF0YS52YWx1ZSA9PT0gJ2RhcmsnID8gVmFybGV0VUkuVGhlbWVzLmRhcmsgOiBudWxsKVxuICAgIH1cbiAgfSlcblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShWYXJsZXRVSSlcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGFwcGVuZFN0eWxlKCkge1xuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgIGxpbmsuaHJlZiA9ICcuL3ZhcmxldC5jc3MnXG4gICAgbGluay5vbmxvYWQgPSByZXNvbHZlXG4gICAgbGluay5vbmVycm9yID0gcmVqZWN0XG4gICAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChsaW5rKVxuICB9KVxufVxuIn0=
