### PR TITLE
docs: remove link to CSDN IDE in README.zh-CN.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,6 @@ See [Varlet UI Playground](https://varlet.gitee.io/varlet-ui-playground).
 
 See [Contributing Guide](https://github.com/varletjs/varlet/blob/dev/.github/CONTRIBUTING.md).
 
-### Start On Cloud IDE
-
-See [Cloud IDE](https://idegithub.com/varletjs/varlet).
-
 ### Community
 
 We recommend that [issue](https://github.com/varletjs/varlet/issues) be used for problem feedback, or others:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,11 +92,6 @@ createApp(App).use(Varlet).mount('#app')
 
 请参考 [Contributing Guide](https://github.com/varletjs/varlet/blob/dev/.github/CONTRIBUTING.md)。
 
-### 在 Cloud IDE 中进行在线开发和调试
-
-在 [Cloud IDE](https://idegithub.com/varletjs/varlet) 对源码进行在线调试。
-
-
 ### 反馈和交流
 
 我们推荐使用`issue`列表进行最直接有效的反馈，也可以下面的方式


### PR DESCRIPTION
## Change information

Modified the `/README.md` and `README.zh-CN.md` to remove the link to CSDN IDE because of bad experience and possible damage to clickers.
![image](https://github.com/varletjs/varlet/assets/43649460/291ffc50-3410-498b-bb1f-e1d4b832c804)
![image](https://github.com/varletjs/varlet/assets/43649460/e2c80811-506b-4dfa-a3e9-395362ebf8b8)
While there are free credits, it's highly unlikely for most people to know that they have to manually close the instance.