### PR TITLE
input 增加text-align: left;避免因为父组件设置text-align: center; 污染输入框 variant="…

### DIFF
--- a/packages/varlet-ui/src/input/input.less
+++ b/packages/varlet-ui/src/input/input.less
@@ -5,6 +5,7 @@
 }
 
 .var-input {
+    text-align: left;
   &__autocomplete {
     width: 0;
     height: 0;

--- a/packages/varlet-ui/src/select/select.less
+++ b/packages/varlet-ui/src/select/select.less
@@ -10,6 +10,7 @@
 }
 
 .var-select {
+  text-align: left;
   &__menu[var-select-cover] {
     width: 100%;
     background: transparent;


### PR DESCRIPTION
…outlined"的样式

## Checklist

List of tasks you have already done and plan to do.

- [ ] 修改父组件文字对齐样式污染输入框的样式，如下图所示。input 增加text-align: left;避免因为父组件设置text-align: center; 污染输入框 variant="outlined"的样式
![image](https://github.com/varletjs/varlet/assets/38217058/5f3ab1c4-f80a-4cac-ab95-394e63ae814a)


## Change information

给input添加了默认样式
.var-input {
    text-align: left;｝

## Issues

 close #1181 .

## Related Links

