### PR TITLE
docs(fab): docs title keeps pace with example title

### DIFF
--- a/packages/varlet-ui/src/fab/docs/zh-CN.md
+++ b/packages/varlet-ui/src/fab/docs/zh-CN.md
@@ -174,7 +174,7 @@ function toggle() {
 </template>
 ```
 
-### 动作菜单显示/隐藏
+### 动作菜单展开/收起
 
 ```html
 <script setup>


### PR DESCRIPTION
## Checklist

List of tasks you have already done and plan to do.

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

I think docs title keeps pace with example title which may be better.

![image](https://github.com/varletjs/varlet/assets/70570907/dfbd5fd2-6a0a-4658-aaf9-63f43dcfee69)

![image](https://github.com/varletjs/varlet/assets/70570907/35199831-8a6c-45f4-8bc7-32c923f7e62a)


## Issues

The issues you want to close, formatted as close #1.

## Related Links

Links related to this pr.
