### PR TITLE
fix(ui/button): button loading icon size follows button

### DIFF
--- a/packages/varlet-ui/src/button/Button.vue
+++ b/packages/varlet-ui/src/button/Button.vue
@@ -35,7 +35,7 @@
       var-button-cover
       :color="loadingColor"
       :type="loadingType"
-      :size="loadingSize"
+      :size="loadingSize || states.size"
       :radius="loadingRadius"
       v-if="loading || pending"
     />

--- a/packages/varlet-ui/src/button/props.ts
+++ b/packages/varlet-ui/src/button/props.ts
@@ -33,7 +33,10 @@ export const props = {
   },
   loadingRadius: [Number, String],
   loadingType: pickProps(loadingProps, 'type'),
-  loadingSize: pickProps(loadingProps, 'size'),
+  loadingSize: {
+    ...pickProps(loadingProps, 'size'),
+    default: undefined,
+  },
   loadingColor: {
     ...pickProps(loadingProps, 'color'),
     default: 'currentColor',


### PR DESCRIPTION
## Checklist

List of tasks you have already done and plan to do.

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

让加载图标的大小跟随按钮大小；目前按钮大小改变后，图标大小还是 normal，需要手动设置 loading-size

## Issues

The issues you want to close, formatted as close #1.

## Related Links

Links related to this pr.
