### PR TITLE
fix(extension): modify prompt bug

### DIFF
--- a/packages/varlet-vscode-extension/src/completions.ts
+++ b/packages/varlet-vscode-extension/src/completions.ts
@@ -76,7 +76,7 @@ export function registerCompletions(context: ExtensionContext) {
   }
 
   const iconsProvider: CompletionItemProvider = {
-    provideCompletionItems(document, position) {
+    provideCompletionItems(document: TextDocument, position: Position) {
       const line = document.getText(
         new Range(new Position(position.line, 0), new Position(position.line, position.character))
       )
@@ -126,7 +126,7 @@ export function registerCompletions(context: ExtensionContext) {
 
       let name: string
       let lastValue: string
-      let startIndex: number
+      let startIndex = 0
 
       // eslint-disable-next-line no-restricted-syntax
       for (const matched of text.matchAll(ATTR_RE)) {
@@ -149,8 +149,10 @@ export function registerCompletions(context: ExtensionContext) {
         return null
       }
 
-      const hasAt = text.endsWith('@')
-      const hasColon = text.endsWith(':')
+      const curString = document.getText().substring(startIndex, endIndex).split(' ')
+      const curSubString = curString[curString.length - 1]
+      const hasAt = curSubString.startsWith('@')
+      const hasColon = curSubString.startsWith(':')
 
       const events = tag.events.map((event) => {
         const item = new CompletionItem(
@@ -161,6 +163,7 @@ export function registerCompletions(context: ExtensionContext) {
           CompletionItemKind.Event
         )
 
+        item.filterText = event.name
         item.documentation = new MarkdownString(`\
 **Event**: ${event.name}
 


### PR DESCRIPTION
## Checklist

List of tasks you have already done and plan to do.

- [ ] Fix prompt errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

When a user enters "@", the prompt information can be correctly matched. However, when a user enters "@s", other prompt information prefixed with "@s", for example, "@select", cannot be matched. This is very unfriendly to the user in the use event prompt. I fixed the issue to make sure users get better code hints. Since hasAt and hasColon get incorrect values when the user types ":s" or "@s", I changed the way I get their values to ensure that I get the correct values in all cases.

