### PR TITLE
fix: fix dialog unmount instance error

### DIFF
--- a/packages/varlet-ui/src/utils/components.ts
+++ b/packages/varlet-ui/src/utils/components.ts
@@ -90,7 +90,9 @@ export function mount(component: Component): MountInstance {
     instance: app.mount(host),
     unmount() {
       app.unmount()
-      document.body.removeChild(host)
+      if (host.parentNode) {
+        document.body.removeChild(host)
+      }
     },
   }
 }


### PR DESCRIPTION
## Checklist

List of tasks you have already done and plan to do.

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

修复 `dialog`,`action-sheet`,`picker` 等组件在 `onClose` 和 `onConfirm` 事件中进行路由跳转导致的异常问题：
```js
  Dialog({
    message: "are you sure?",
    confirmButtonText: "yes",
    onConfirm: () => {
      router.back();
    },
  });
```
异常信息：
```
Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
``` 

原因是组件内部的以下的两个事件都调用了一次 `unmountInstance` 方法，在第二次调用时 `dom` 元素已经不在 `body` 中了，所以调用 `document.body.removeChild(host)` 会报错
```js
    onClosed: () => {
      call(reactivePickerOptions.onClosed)
      unmountInstance()
      resetSingletonOptions()
    },
    onRouteChange: () => {
      unmountInstance()
      resetSingletonOptions()
    }
```

## Issues

The issues you want to close, formatted as close #1.

## Related Links

[点击跳转最小复现代码](https://github.com/lzj97/varlet-demo)
复现步骤：
启动后点击 `about` 按钮跳转到 `about` 页面，然后点击 `go back` 弹出窗口，点击 `yes` 即可复现
