### PR TITLE
Feature/radio group accessibility

### DIFF
--- a/packages/varlet-ui/src/form/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/varlet-ui/src/form/__tests__/__snapshots__/index.spec.js.snap
@@ -419,8 +419,8 @@ exports[`form with input 4`] = `
 
 exports[`form with radio 1`] = `
 "<form class="var-form">
-  <div class="var-radio__wrap">
-    <div class="var-radio">
+  <li class="var-radio__wrap">
+    <div role="radio" aria-checked="false" class="var-radio">
       <div class="var-radio__action var-radio--unchecked var-radio--disabled"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
         <div class="var-hover-overlay"></div>
       </div>
@@ -429,14 +429,14 @@ exports[`form with radio 1`] = `
     <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-  </div>
+  </li>
 </form>"
 `;
 
 exports[`form with radio 2`] = `
 "<form class="var-form">
-  <div class="var-radio__wrap">
-    <div class="var-radio">
+  <li class="var-radio__wrap">
+    <div role="radio" aria-checked="false" class="var-radio">
       <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
         <div class="var-hover-overlay"></div>
       </div>
@@ -445,14 +445,14 @@ exports[`form with radio 2`] = `
     <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-  </div>
+  </li>
 </form>"
 `;
 
 exports[`form with radio 3`] = `
 "<form class="var-form">
-  <div class="var-radio__wrap">
-    <div class="var-radio">
+  <li class="var-radio__wrap">
+    <div role="radio" aria-checked="false" class="var-radio">
       <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
         <div class="var-hover-overlay"></div>
       </div>
@@ -472,14 +472,14 @@ exports[`form with radio 3`] = `
         </div>
       </div>
     </transition-stub>
-  </div>
+  </li>
 </form>"
 `;
 
 exports[`form with radio 4`] = `
 "<form class="var-form">
-  <div class="var-radio__wrap">
-    <div class="var-radio">
+  <li class="var-radio__wrap">
+    <div role="radio" aria-checked="false" class="var-radio">
       <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
         <div class="var-hover-overlay"></div>
       </div>
@@ -488,7 +488,7 @@ exports[`form with radio 4`] = `
     <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-  </div>
+  </li>
 </form>"
 `;
 

--- a/packages/varlet-ui/src/radio-group/RadioGroup.vue
+++ b/packages/varlet-ui/src/radio-group/RadioGroup.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="n('wrap')">
-    <div :class="classes(n(), n(`--${direction}`))">
+    <ul :aria-label="ariaLabel" role="radiogroup" :class="classes(n(), n(`--${direction}`))">
       <template v-if="options.length">
         <var-radio
           v-for="option in options"
@@ -14,7 +14,7 @@
         </var-radio>
       </template>
       <slot />
-    </div>
+    </ul>
 
     <var-form-details :error-message="errorMessage" />
   </div>

--- a/packages/varlet-ui/src/radio-group/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/varlet-ui/src/radio-group/__tests__/__snapshots__/index.spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`radio group label is VNode 1`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text">
@@ -15,10 +15,10 @@ exports[`radio group label is VNode 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text">
@@ -28,9 +28,9 @@ exports[`radio group label is VNode 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
         <div class="var-radio__action var-radio--unchecked var-radio--disabled"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -41,8 +41,8 @@ exports[`radio group label is VNode 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -51,10 +51,10 @@ exports[`radio group label is VNode 1`] = `
 
 exports[`radio group label is function 1`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>0-false</span></div>
@@ -62,10 +62,10 @@ exports[`radio group label is function 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>1-false</span></div>
@@ -73,9 +73,9 @@ exports[`radio group label is function 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
         <div class="var-radio__action var-radio--unchecked var-radio--disabled"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -84,8 +84,8 @@ exports[`radio group label is function 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -94,10 +94,10 @@ exports[`radio group label is function 1`] = `
 
 exports[`radio group label is function 2`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>0-false</span></div>
@@ -105,9 +105,9 @@ exports[`radio group label is function 2`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="true" class="var-radio">
         <div class="var-radio__action var-radio--checked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-marked var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -116,9 +116,9 @@ exports[`radio group label is function 2`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
         <div class="var-radio__action var-radio--unchecked var-radio--disabled"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -127,8 +127,8 @@ exports[`radio group label is function 2`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -137,10 +137,10 @@ exports[`radio group label is function 2`] = `
 
 exports[`radio group label is function 3`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>0-false</span></div>
@@ -148,9 +148,9 @@ exports[`radio group label is function 3`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="true" class="var-radio">
         <div class="var-radio__action var-radio--checked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-marked var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -159,9 +159,9 @@ exports[`radio group label is function 3`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
         <div class="var-radio__action var-radio--unchecked var-radio--disabled"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -170,8 +170,8 @@ exports[`radio group label is function 3`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -180,10 +180,10 @@ exports[`radio group label is function 3`] = `
 
 exports[`radio group label-key 1`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>eat</span></div>
@@ -191,10 +191,10 @@ exports[`radio group label-key 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>sleep</span></div>
@@ -202,9 +202,9 @@ exports[`radio group label-key 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
         <div class="var-radio__action var-radio--unchecked var-radio--disabled"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -213,8 +213,8 @@ exports[`radio group label-key 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -223,11 +223,11 @@ exports[`radio group label-key 1`] = `
 
 exports[`radio group layout direction 1`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--vertical">
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--vertical">
     <!--v-if-->
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <!--v-if-->
@@ -235,10 +235,10 @@ exports[`radio group layout direction 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <!--v-if-->
@@ -246,8 +246,8 @@ exports[`radio group layout direction 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -256,10 +256,10 @@ exports[`radio group layout direction 1`] = `
 
 exports[`radio group options 1`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>eat</span></div>
@@ -267,10 +267,10 @@ exports[`radio group options 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>sleep</span></div>
@@ -278,9 +278,9 @@ exports[`radio group options 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
         <div class="var-radio__action var-radio--unchecked var-radio--disabled"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -289,8 +289,8 @@ exports[`radio group options 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -299,11 +299,11 @@ exports[`radio group options 1`] = `
 
 exports[`radio group validation 1`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
     <!--v-if-->
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <!--v-if-->
@@ -311,9 +311,9 @@ exports[`radio group validation 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="true" class="var-radio">
         <div class="var-radio__action var-radio--checked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-marked var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -322,8 +322,8 @@ exports[`radio group validation 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <div class="var-form-details">
       <div class="var-form-details__error-message">
@@ -343,10 +343,10 @@ exports[`radio group validation 1`] = `
 
 exports[`radio group validation 2`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
     <!--v-if-->
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="true" class="var-radio">
         <div class="var-radio__action var-radio--checked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-marked var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -355,10 +355,10 @@ exports[`radio group validation 2`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <!--v-if-->
@@ -366,8 +366,8 @@ exports[`radio group validation 2`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -376,10 +376,10 @@ exports[`radio group validation 2`] = `
 
 exports[`radio group value-key 1`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>eat</span></div>
@@ -387,10 +387,10 @@ exports[`radio group value-key 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <div class="var-radio__text"><span>sleep</span></div>
@@ -398,9 +398,9 @@ exports[`radio group value-key 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
         <div class="var-radio__action var-radio--unchecked var-radio--disabled"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -409,8 +409,8 @@ exports[`radio group value-key 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
@@ -418,9 +418,9 @@ exports[`radio group value-key 1`] = `
 `;
 
 exports[`radio validation 1`] = `
-"<div class="var-radio__wrap">
-  <div class="var-radio">
-    <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+"<li class="var-radio__wrap">
+  <div role="radio" aria-checked="false" class="var-radio">
+    <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
       <div class="var-hover-overlay"></div>
     </div>
     <!--v-if-->
@@ -439,12 +439,12 @@ exports[`radio validation 1`] = `
       </div>
     </div>
   </transition-stub>
-</div>"
+</li>"
 `;
 
 exports[`radio validation 2`] = `
-"<div class="var-radio__wrap">
-  <div class="var-radio">
+"<li class="var-radio__wrap">
+  <div role="radio" aria-checked="true" class="var-radio">
     <div class="var-radio__action var-radio--checked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-marked var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
       <div class="var-hover-overlay"></div>
     </div>
@@ -453,13 +453,13 @@ exports[`radio validation 2`] = `
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
-</div>"
+</li>"
 `;
 
 exports[`test validation with zod > radio 1`] = `
-"<div class="var-radio__wrap">
-  <div class="var-radio">
-    <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+"<li class="var-radio__wrap">
+  <div role="radio" aria-checked="false" class="var-radio">
+    <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
       <div class="var-hover-overlay"></div>
     </div>
     <!--v-if-->
@@ -478,12 +478,12 @@ exports[`test validation with zod > radio 1`] = `
       </div>
     </div>
   </transition-stub>
-</div>"
+</li>"
 `;
 
 exports[`test validation with zod > radio 2`] = `
-"<div class="var-radio__wrap">
-  <div class="var-radio">
+"<li class="var-radio__wrap">
+  <div role="radio" aria-checked="true" class="var-radio">
     <div class="var-radio__action var-radio--checked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-marked var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
       <div class="var-hover-overlay"></div>
     </div>
@@ -492,16 +492,16 @@ exports[`test validation with zod > radio 2`] = `
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
-</div>"
+</li>"
 `;
 
 exports[`test validation with zod > radio group 1`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
     <!--v-if-->
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <!--v-if-->
@@ -509,9 +509,9 @@ exports[`test validation with zod > radio group 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="true" class="var-radio">
         <div class="var-radio__action var-radio--checked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-marked var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -520,8 +520,8 @@ exports[`test validation with zod > radio group 1`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <div class="var-form-details">
       <div class="var-form-details__error-message">
@@ -541,10 +541,10 @@ exports[`test validation with zod > radio group 1`] = `
 
 exports[`test validation with zod > radio group 2`] = `
 "<div class="var-radio-group__wrap">
-  <div class="var-radio-group var-radio-group--horizontal">
+  <ul aria-label="" role="radiogroup" class="var-radio-group var-radio-group--horizontal">
     <!--v-if-->
-    <div class="var-radio__wrap">
-      <div class="var-radio">
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="true" class="var-radio">
         <div class="var-radio__action var-radio--checked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-marked var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
@@ -553,10 +553,10 @@ exports[`test validation with zod > radio group 2`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-    <div class="var-radio__wrap">
-      <div class="var-radio">
-        <div class="var-radio__action var-radio--unchecked" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    </li>
+    <li class="var-radio__wrap">
+      <div role="radio" aria-checked="false" class="var-radio">
+        <div class="var-radio__action var-radio--unchecked" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
           <div class="var-hover-overlay"></div>
         </div>
         <!--v-if-->
@@ -564,8 +564,8 @@ exports[`test validation with zod > radio group 2`] = `
       <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
         <!--v-if-->
       </transition-stub>
-    </div>
-  </div>
+    </li>
+  </ul>
   <transition-stub name="var-form-details" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>

--- a/packages/varlet-ui/src/radio-group/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/varlet-ui/src/radio-group/__tests__/__snapshots__/index.spec.js.snap
@@ -420,7 +420,7 @@ exports[`radio group value-key 1`] = `
 exports[`radio validation 1`] = `
 "<li class="var-radio__wrap">
   <div role="radio" aria-checked="false" class="var-radio">
-    <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
       <div class="var-hover-overlay"></div>
     </div>
     <!--v-if-->
@@ -459,7 +459,7 @@ exports[`radio validation 2`] = `
 exports[`test validation with zod > radio 1`] = `
 "<li class="var-radio__wrap">
   <div role="radio" aria-checked="false" class="var-radio">
-    <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="-1"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
+    <div class="var-radio__action var-radio--unchecked var-radio--error" tabindex="0"><i class="var-icon var-icon--set var-icon-radio-blank var-radio__icon" style="transition-duration: 0ms;" var-radio-cover=""></i>
       <div class="var-hover-overlay"></div>
     </div>
     <!--v-if-->

--- a/packages/varlet-ui/src/radio-group/__tests__/index.spec.js
+++ b/packages/varlet-ui/src/radio-group/__tests__/index.spec.js
@@ -310,6 +310,39 @@ test('radio group options', async () => {
   wrapper.unmount()
 })
 
+test('radio accessibility', async () => {
+  const wrapper = mount({
+    components: {
+      [VarRadioGroup.name]: VarRadioGroup,
+      [VarRadio.name]: VarRadio,
+    },
+    data: () => ({
+      value: null,
+      options: [
+        { label: 'eat', value: 0 },
+        { label: 'sleep', value: 1 },
+      ],
+    }),
+    template: `
+      <var-radio-group v-model="value" :options="options" aria-label="Radio Group">
+      </var-radio-group>
+    `,
+  })
+
+  const group = wrapper.find('.var-radio-group')
+  expect(group.attributes('role')).toBe('radiogroup')
+  expect(group.attributes('aria-label')).toBe('Radio Group')
+
+  const children = wrapper.findAll('.var-radio')
+  const option = children[0]
+
+  await trigger(option, 'click')
+
+  expect(option.attributes('aria-checked')).toBe('true')
+
+  wrapper.unmount()
+})
+
 test('radio group label-key', async () => {
   const wrapper = mount({
     components: {

--- a/packages/varlet-ui/src/radio-group/docs/en-US.md
+++ b/packages/varlet-ui/src/radio-group/docs/en-US.md
@@ -269,6 +269,7 @@ const value = ref(false)
 | `label-key` ***3.2.14*** | As the key that uniquely identifies label | _string_ | `label` |
 | `value-key` ***3.2.14*** | As the key that uniquely identifies value | _string_ | `value` |
 | `rules` | Validation rules, return `true` to indicate verification passes, other types of values ​​will be converted into text as user prompts. [Zod validation](#/en-US/zodValidation) is supported since `3.5.0` | _(v: any) => any \| ZodType \| Array<(v: any) => any \| ZodType>_ | `-` |
+| `aria-label` ***3.8.5*** | The label of the radio group | _string_ | `-` |
 
 #### RadioGroupOption
 

--- a/packages/varlet-ui/src/radio-group/docs/zh-CN.md
+++ b/packages/varlet-ui/src/radio-group/docs/zh-CN.md
@@ -269,6 +269,7 @@ const value = ref(false)
 | `label-key` ***3.2.14*** | 作为 label 唯一标识的键名 | _string_ | `label` |
 | `value-key` ***3.2.14*** | 作为 value 唯一标识的键名 | _string_ | `value` |
 | `rules` | 验证规则，返回 `true` 表示验证通过，其它类型的值将转换为文本作为用户提示。自 `3.5.0` 开始支持 [Zod 验证](#/zh-CN/zodValidation)  | _((v: any) => any) \| ZodType \| Array<((v: any) => any) \| ZodType>_ | `-` |
+| `aria-label` ***3.8.5*** | 单选框组的标签 | _string_ | `-` |
 
 #### RadioGroupOption
 

--- a/packages/varlet-ui/src/radio-group/props.ts
+++ b/packages/varlet-ui/src/radio-group/props.ts
@@ -28,6 +28,10 @@ export const props = {
     type: Array as PropType<RadioGroupOption[]>,
     default: () => [],
   },
+  ariaLabel: {
+    type: String,
+    default: '',
+  },
   labelKey: {
     type: String,
     default: 'label',

--- a/packages/varlet-ui/src/radio-group/radioGroup.less
+++ b/packages/varlet-ui/src/radio-group/radioGroup.less
@@ -1,6 +1,9 @@
 .var-radio-group {
   display: flex;
   flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 
   &--horizontal {
     flex-direction: row;

--- a/packages/varlet-ui/src/radio/Radio.vue
+++ b/packages/varlet-ui/src/radio/Radio.vue
@@ -13,7 +13,7 @@
             [formDisabled || disabled, n('--disabled')],
           )
         "
-        :tabindex="formDisabled || disabled ? undefined : checked ? '0' : '-1'"
+        :tabindex="tabIndex"
         :style="{ color: checked ? checkedColor : uncheckedColor }"
         @focus="isFocusing = true"
         @blur="isFocusing = false"
@@ -82,6 +82,14 @@ export default defineComponent({
     const { radioGroup, bindRadioGroup } = useRadioGroup()
     const { hovering, handleHovering } = useHoverOverlay()
     const { form, bindForm } = useForm()
+    const tabIndex = computed(() => {
+      console.log(radioGroup)
+      return form?.disabled.value || props.disabled
+        ? undefined
+        : checked.value || (!checked.value && !radioGroup)
+          ? '0'
+          : '-1'
+    })
     const {
       errorMessage,
       validateWithTrigger: vt,
@@ -216,6 +224,7 @@ export default defineComponent({
       formDisabled: form?.disabled,
       formReadonly: form?.readonly,
       hovering,
+      tabIndex,
       handleHovering,
       n,
       classes,

--- a/packages/varlet-ui/src/radio/Radio.vue
+++ b/packages/varlet-ui/src/radio/Radio.vue
@@ -1,6 +1,6 @@
 <template>
-  <div :class="n('wrap')">
-    <div :class="n()" v-bind="$attrs" @click="handleClick">
+  <li :class="n('wrap')">
+    <div role="radio" :aria-checked="checked" :class="n()" v-bind="$attrs" @click="handleClick">
       <div
         ref="action"
         v-ripple="{ disabled: formReadonly || readonly || formDisabled || disabled || !ripple }"
@@ -13,7 +13,7 @@
             [formDisabled || disabled, n('--disabled')],
           )
         "
-        :tabindex="formDisabled || disabled ? undefined : '0'"
+        :tabindex="formDisabled || disabled ? undefined : checked ? '0' : '-1'"
         :style="{ color: checked ? checkedColor : uncheckedColor }"
         @focus="isFocusing = true"
         @blur="isFocusing = false"
@@ -45,7 +45,7 @@
     </div>
 
     <var-form-details :error-message="errorMessage" />
-  </div>
+  </li>
 </template>
 
 <script lang="ts">

--- a/packages/varlet-ui/types/radioGroup.d.ts
+++ b/packages/varlet-ui/types/radioGroup.d.ts
@@ -28,6 +28,7 @@ export interface RadioGroupProps extends BasicAttributes {
   modelValue?: any
   direction?: RadioGroupDirection
   options?: RadioGroupOption[]
+  ariaLabel?: string
   labelKey?: string
   valueKey?: string
   validateTrigger?: RadioGroupValidateTrigger[]


### PR DESCRIPTION
Update according to w3c https://www.w3.org/WAI/ARIA/apg/patterns/radio/

- Dynamically set `tabindex` based on checked state - changing radio options should not be achieved through tab key - only initial focus 
- Add `role="radio"` and `aria-checked` attributes to radio component
- Change radio wrapper from `<div>` to `<li>` for better semantics
- Add `ariaLabel` prop to radio group for improved accessibility
- Update radio group to use `<ul>` with `role="radiogroup"`

## Checklist

List of tasks you have already done and plan to do.

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

Describe your modifications here.

## Issues

The issues you want to close, formatted as close #1.

## Related Links

Links related to this pr.
