### PR TITLE
fix(ui/collapse-item): use correct css variable to control `divider`

### DIFF
--- a/packages/varlet-ui/src/collapse-item/collapseItem.less
+++ b/packages/varlet-ui/src/collapse-item/collapseItem.less
@@ -32,7 +32,7 @@
   }
 
   &:not(:first-child)::after {
-    border-top: var(--collapse-border-top);
+    border-top: var(--collapse-divider-top);
     content: '';
     left: 0;
     position: absolute;


### PR DESCRIPTION
## Checklist

List of tasks you have already done and plan to do.

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information


https://github.com/user-attachments/assets/40024cde-6976-4c84-96fe-acdbecdc55c5



## Issues

close #1876

## Related Links

Links related to this pr.
