### PR TITLE
docs: fix english quotation conflict

### DIFF
--- a/packages/varlet-ui/src/snackbar/docs/en-US.md
+++ b/packages/varlet-ui/src/snackbar/docs/en-US.md
@@ -141,7 +141,7 @@ import { Snackbar } from '@varlet/ui'
 </script>
 
 <template>
-  <var-button type="warning" block @click="Snackbar('Hello, I'm a snackbar')">Basic Usage</var-button>
+  <var-button type="warning" block @click="Snackbar('Hello, I\'m a snackbar')">Basic Usage</var-button>
 </template>
 ```
 


### PR DESCRIPTION
```diff
- <var-button type="warning" block @click="Snackbar('Hello, I'm a snackbar')">Basic Usage</var-button>

+ <var-button type="warning" block @click="Snackbar('Hello, I\'m a snackbar')">Basic Usage</var-button>
```

Fix english quotation conflict