### PR TITLE
fix(snackbar): update content styles

### DIFF
--- a/packages/varlet-ui/src/snackbar/snackbar.less
+++ b/packages/varlet-ui/src/snackbar/snackbar.less
@@ -95,6 +95,7 @@
 
   &__content {
     flex-grow: 1;
+    word-break: break-all;
     padding: var(--snackbar-content-padding);
   }
 


### PR DESCRIPTION
Fixed Snackbar content text wrapping automatically.

<img width="371" height="95" alt="image" src="https://github.com/user-attachments/assets/f1d755ef-a70e-4f42-af67-d319becc10ef" />
