### PR TITLE
fix(otp-input): support autofill on mobile

### DIFF
--- a/packages/varlet-ui/src/otp-input/OtpInput.vue
+++ b/packages/varlet-ui/src/otp-input/OtpInput.vue
@@ -18,7 +18,6 @@
             :ref="(el) => setInputRef(el, index)"
             :model-value="getDisplayChar(index)"
             :type="nativeInputType"
-            :maxlength="1"
             autocomplete="one-time-code"
             placeholder=""
             :hint="false"
@@ -49,7 +48,7 @@
 </template>
 
 <script lang="ts">
-import { call, clamp, toNumber } from '@varlet/shared'
+import { call, clamp, raf, toNumber } from '@varlet/shared'
 import { onSmartMounted } from '@varlet/use'
 import { computed, defineComponent, nextTick, ref, useSlots, type ComponentPublicInstance } from 'vue'
 import VarFormDetails from '../form-details'
@@ -174,9 +173,13 @@ export default defineComponent({
       maybeEmitComplete(value)
     }
 
-    function focusCell(index: number) {
+    async function focusCell(index: number) {
       const targetIndex = clamp(index, 0, normalizedLength.value - 1)
       inputRefs.value[targetIndex]?.focus?.()
+      await raf()
+      if (document.activeElement === inputRefs.value[targetIndex]?.el) {
+        inputRefs.value[targetIndex]?.select?.()
+      }
     }
 
     // expose
@@ -291,20 +294,23 @@ export default defineComponent({
         return
       }
 
+      const target = event.target as HTMLElement | null
+      const cell = target?.closest(`.${n('cell')}`) as HTMLElement | null
+      const indexAttr = cell?.dataset.index
+
       call(props.onClick, event)
       validateWithTrigger('onClick')
+
+      if (indexAttr == null) {
+        return
+      }
+
+      focusCell(Number(indexAttr))
     }
 
     function handleFocus(index: number) {
-      const valueChars = getValueChars()
-
       activeIndex.value = index
-
-      if (valueChars[index]) {
-        nextTick(() => {
-          inputRefs.value[index]?.select?.()
-        })
-      }
+      focusCell(index)
     }
 
     function handleBlur(event: FocusEvent) {
@@ -332,6 +338,7 @@ export default defineComponent({
           removeAt(index)
         } else {
           syncCellDisplayValue(index)
+          scheduleFocusEffect(index)
         }
 
         return

--- a/packages/varlet-ui/src/otp-input/__tests__/index.spec.js
+++ b/packages/varlet-ui/src/otp-input/__tests__/index.spec.js
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vite-plus/test'
 import { createApp } from 'vue'
 import OtpInput from '..'
+import { delay } from '../../utils/test'
 import VarOtpInput from '../OtpInput.vue'
 
 test('otp-input plugin', () => {
@@ -73,6 +74,30 @@ describe('test otp-input behaviors', () => {
     wrapper.unmount()
   })
 
+  test('input event with multiple chars should fill from the first empty cell', async () => {
+    const onUpdateModelValue = vi.fn((value) => wrapper.setProps({ modelValue: value }))
+
+    const wrapper = mount(VarOtpInput, {
+      props: {
+        modelValue: '',
+        length: 6,
+        'onUpdate:modelValue': onUpdateModelValue,
+      },
+    })
+
+    const inputs = wrapper.findAll('.var-input__input')
+
+    await inputs[2].trigger('focus')
+    await inputs[2].setValue('123456')
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(onUpdateModelValue).toHaveBeenLastCalledWith('123456')
+    expect(wrapper.vm.activeIndex).toBe(5)
+
+    wrapper.unmount()
+  })
+
   test('click should emit event and trigger onClick validation', async () => {
     const onClick = vi.fn()
     const rule = vi.fn(() => true)
@@ -96,6 +121,31 @@ describe('test otp-input behaviors', () => {
     expect(rule).toHaveBeenCalled()
     expect(rule.mock.calls[0][0]).toBe('')
 
+    wrapper.unmount()
+  })
+
+  test('click filled cell should keep selection', async () => {
+    const wrapper = mount(VarOtpInput, {
+      props: {
+        modelValue: '1234',
+        length: 4,
+      },
+      attachTo: document.body,
+    })
+
+    const inputs = wrapper.findAll('.var-input__input')
+    const selectSpy = vi.spyOn(inputs[0].element, 'select')
+
+    inputs[0].element.focus()
+    await delay(20)
+    selectSpy.mockClear()
+
+    await inputs[0].trigger('click')
+    await delay(20)
+
+    expect(selectSpy).toHaveBeenCalled()
+
+    selectSpy.mockRestore()
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Checklist

List of tasks you have already done and plan to do.

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

Describe your modifications here.

## Issues

On mobile devices, especially in Safari and Firefox, autofilling verification codes does not trigger the paste event. Therefore, we need to support entering multiple characters into a single cell within the input component. Fortunately, our implementation already handles this case.

## Related Links

https://stackoverflow.com/questions/73704634/autoread-otp-in-web-and-copy-paste-otp-from-clipboard-in-web-not-working-for-and/73757650#73757650
