### PR TITLE
feat(cli): detect browser language for site documentation auto-redirect

### DIFF
--- a/packages/varlet-cli/site/mobile/main.ts
+++ b/packages/varlet-cli/site/mobile/main.ts
@@ -3,13 +3,13 @@ import config from '@config'
 import routes from '@mobile-routes'
 import Varlet from '@varlet/ui'
 import { createRouter, createWebHashHistory } from 'vue-router'
-import { inIframe, isPhone } from '../utils'
+import { getBrowserLanguage, inIframe, isPhone } from '../utils'
 import App from './App.vue'
 import '@varlet/touch-emulator'
 import '@varlet/ui/es/style'
 
 const redirect = config?.mobile?.redirect
-const defaultLanguage = config?.defaultLanguage
+const defaultLanguage = config?.defaultLanguage ?? getBrowserLanguage()
 
 redirect &&
   routes.push({

--- a/packages/varlet-cli/site/pc/App.vue
+++ b/packages/varlet-cli/site/pc/App.vue
@@ -2,12 +2,12 @@
 import { defineComponent, onMounted, ref } from 'vue'
 import config from '@config'
 import { getMobileIndex, getPCLocationInfo } from '@varlet/cli/client'
-import { isPhone } from '../utils'
+import { getBrowserLanguage, isPhone } from '../utils'
 
 export default defineComponent({
   setup() {
     const useMobile = ref(config?.useMobile)
-    const defaultLanguage = config?.defaultLanguage
+    const defaultLanguage = config?.defaultLanguage ?? getBrowserLanguage()
 
     const init = () => {
       const { language, menuName } = getPCLocationInfo()

--- a/packages/varlet-cli/site/pc/main.ts
+++ b/packages/varlet-cli/site/pc/main.ts
@@ -5,10 +5,11 @@ import Varlet, { Snackbar } from '@varlet/ui'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import App from './App.vue'
 import CodeExample from './components/code-example'
+import { getBrowserLanguage } from '../utils'
 import '@varlet/ui/es/style'
 import '@varlet/touch-emulator'
 
-const defaultLanguage = config?.defaultLanguage
+const defaultLanguage = config?.defaultLanguage ?? getBrowserLanguage()
 const redirect = config?.pc?.redirect
 const mobileRedirect = config?.mobile?.redirect
 

--- a/packages/varlet-cli/site/utils.ts
+++ b/packages/varlet-cli/site/utils.ts
@@ -30,3 +30,7 @@ export function inIframe() {
 export function utoa(data: string): string {
   return btoa(unescape(encodeURIComponent(data)))
 }
+
+export function getBrowserLanguage(): string {
+  return navigator.language.startsWith('zh') ? 'zh-CN' : 'en-US'
+}

--- a/packages/varlet-cli/src/node/config/varlet.default.config.ts
+++ b/packages/varlet-cli/src/node/config/varlet.default.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
   port: 8080,
   title: 'VARLET',
   logo: 'varlet_icon.png',
-  defaultLanguage: 'zh-CN',
   themeKey: 'VARLET_V3_THEME',
   defaultLightTheme: 'md3LightTheme',
   defaultDarkTheme: 'md3DarkTheme',


### PR DESCRIPTION
When defaultLanguage is not explicitly set in site config, the site will now detect the user's browser language via navigator.language and auto-redirect to the corresponding zh-CN or en-US documentation.

## Checklist

List of tasks you have already done and plan to do.

- [x] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)
