### PR TITLE
fix(cli): generate web-types with real props and update events for v-model bindings

### DIFF
--- a/packages/varlet-cli/src/node/compiler/compileTemplateHighlight.ts
+++ b/packages/varlet-cli/src/node/compiler/compileTemplateHighlight.ts
@@ -38,6 +38,22 @@ export const replaceVersion = (s: string) => s.replace(/\*\*\*.+\*\*\*/g, '').tr
 
 export const replaceUnderline = (s: string) => s.replace(/_/g, '')
 
+export const camelize = (s: string) => s.replace(/-(\w)/g, (_, c) => (c ? c.toUpperCase() : ''))
+
+export function parseVModelName(name: string): { attribute: string; event: string } | null {
+  if (name === 'v-model') {
+    return { attribute: 'model-value', event: 'update:modelValue' }
+  }
+
+  const matched = name.match(/^v-model:(.+)$/)
+  if (matched) {
+    const arg = matched[1]
+    return { attribute: arg, event: `update:${camelize(arg)}` }
+  }
+
+  return null
+}
+
 export function parseTable(table: string) {
   const rows = table.split('\n').filter(Boolean)
   return rows.map((row) => {
@@ -84,20 +100,37 @@ export function compileWebTypes(
 ) {
   const { attributesTable, eventsTable, slotsTable } = table
 
-  const attributes = attributesTable.map((row: any) => ({
-    name: replaceVersion(replaceDot(row[0])),
-    description: row[1],
-    default: replaceDot(row[3]),
-    value: {
-      type: replaceUnderline(row[2]),
-      kind: 'expression',
-    },
-  }))
+  const modelEvents: Array<{ name: string; description: string }> = []
+
+  const attributes = attributesTable.map((row: any) => {
+    const name = replaceVersion(replaceDot(row[0]))
+    const vModel = parseVModelName(name)
+
+    if (vModel) {
+      modelEvents.push({ name: vModel.event, description: row[1] })
+    }
+
+    return {
+      name: vModel ? vModel.attribute : name,
+      description: row[1],
+      default: replaceDot(row[3]),
+      value: {
+        type: replaceUnderline(row[2]),
+        kind: 'expression',
+      },
+    }
+  })
 
   const events = eventsTable.map((row: any) => ({
     name: replaceVersion(replaceDot(row[0])),
     description: row[1],
   }))
+
+  modelEvents.forEach((modelEvent) => {
+    if (!events.some((event: { name: string }) => event.name === modelEvent.name)) {
+      events.push(modelEvent)
+    }
+  })
 
   const slots = slotsTable.map((row: any) => ({
     name: replaceVersion(replaceDot(row[0])),


### PR DESCRIPTION
## Checklist

List of tasks you have already done and plan to do.

- [x] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

> Note: `@varlet/cli` has no unit-test runner configured (it only *provides* the
> vitest config consumed by `@varlet/ui`), so this change is verified by the
> regenerated `web-types.json` output and a minimal Vite + Vue 3 reproduction
> project rather than an automated test.

## Change information

WebStorm's newer JetBrains Vue schema validates `v-model:<arg>` against a
component's declared **prop + matching `update:*` event**, instead of accepting a
literal `v-model:show` attribute entry. Because the generated `web-types.json`
emitted the binding as a literal attribute named `v-model:show` (and no
`update:show` event), WebStorm reported the value as invalid.

This only affects WebStorm/IDE static analysis — the app runs fine and Volar /
`vue-tsc` already accept the binding.

This PR updates the web-types compiler (`compileTemplateHighlight.ts`) so that
documentation entries written with the directive form are translated into the
underlying prop name plus the companion update event:

| doc table entry | attribute emitted | event emitted |
| --- | --- | --- |
| `v-model` | `model-value` | `update:modelValue` |
| `v-model:show` | `show` | `update:show` |
| `v-model:active-key` | `active-key` | `update:activeKey` |

Existing `update:*` events already declared in the events table are de-duplicated.

After regenerating, `var-popup` / `var-dialog` expose `show` + `update:show`
(instead of a literal `v-model:show` attribute), and WebStorm no longer warns.

## Issues

#1935

## Related Links

N/A